### PR TITLE
Fixed error 'TypeError: only integer scalar arrays can be converted to a scalar index'

### DIFF
--- a/input_data.py
+++ b/input_data.py
@@ -22,7 +22,7 @@ def maybe_download(filename, work_directory):
 
 def _read32(bytestream):
     dt = numpy.dtype(numpy.uint32).newbyteorder('>')
-    return numpy.frombuffer(bytestream.read(4), dtype=dt)
+    return numpy.frombuffer(bytestream.read(4), dtype=dt)[0]
 
 
 def extract_images(filename):


### PR DESCRIPTION
Solution found here: http://stackoverflow.com/questions/34010859/tensorflow-beginner-tutorial-read-data-sets-fails#34060136