### PR TITLE
Update tensorflow methods to Python 3.6, tf 1.8

### DIFF
--- a/board.py
+++ b/board.py
@@ -1,6 +1,6 @@
 # Import MNIST data
 import input_data
-mnist = input_data.read_data_sets("/tmp/data/", one_hot=True)
+mnist = input_data.read_data_sets("data/", one_hot=True)
 
 import tensorflow as tf
 
@@ -25,8 +25,8 @@ with tf.name_scope("Wx_b") as scope:
     model = tf.nn.softmax(tf.matmul(x, W) + b) # Softmax
     
 # Add summary ops to collect data
-w_h = tf.histogram_summary("weights", W)
-b_h = tf.histogram_summary("biases", b)
+w_h = tf.summary.histogram("weights", W)
+b_h = tf.summary.histogram("biases", b)
 
 # More name scopes will clean up graph representation
 with tf.name_scope("cost_function") as scope:
@@ -34,7 +34,7 @@ with tf.name_scope("cost_function") as scope:
     # Cross entropy
     cost_function = -tf.reduce_sum(y*tf.log(model))
     # Create a summary to monitor the cost function
-    tf.scalar_summary("cost_function", cost_function)
+    tf.summary.scalar("cost_function", cost_function)
 
 with tf.name_scope("train") as scope:
     # Gradient descent
@@ -44,7 +44,7 @@ with tf.name_scope("train") as scope:
 init = tf.initialize_all_variables()
 
 # Merge all summaries into a single operator
-merged_summary_op = tf.merge_all_summaries()
+merged_summary_op = tf.summary.merge_all()
 
 # Launch the graph
 with tf.Session() as sess:
@@ -53,7 +53,7 @@ with tf.Session() as sess:
     
     
     # Change this to a location on your computer
-    summary_writer = tf.train.SummaryWriter('/LOCATION/ON/YOUR/COMPUTER/', graph_def=sess.graph_def)
+    summary_writer = tf.summary.FileWriter('data/logs', graph_def=sess.graph_def)
 
     # Training cycle
     for iteration in range(training_iteration):
@@ -71,12 +71,12 @@ with tf.Session() as sess:
             summary_writer.add_summary(summary_str, iteration*total_batch + i)
         # Display logs per iteration step
         if iteration % display_step == 0:
-            print "Iteration:", '%04d' % (iteration + 1), "cost=", "{:.9f}".format(avg_cost)
+            print("Iteration:", '%04d' % (iteration + 1), "cost=", "{:.9f}".format(avg_cost))
 
-    print "Tuning completed!"
+    print("Tuning completed!")
 
     # Test the model
     predictions = tf.equal(tf.argmax(model, 1), tf.argmax(y, 1))
     # Calculate accuracy
     accuracy = tf.reduce_mean(tf.cast(predictions, "float"))
-    print "Accuracy:", accuracy.eval({x: mnist.test.images, y: mnist.test.labels})
+    print("Accuracy:", accuracy.eval({x: mnist.test.images, y: mnist.test.labels}))

--- a/input_data.py
+++ b/input_data.py
@@ -22,7 +22,7 @@ def maybe_download(filename, work_directory):
 
 def _read32(bytestream):
     dt = numpy.dtype(numpy.uint32).newbyteorder('>')
-    return numpy.frombuffer(bytestream.read(4), dtype=dt)
+    return numpy.frombuffer(bytestream.read(4), dtype=dt)[0]
 
 
 def extract_images(filename):


### PR DESCRIPTION
- updates for Tensorflow 1.8 and Python 3.6
- graph_def is being deprecated but still works as an input
- as noted previously numpy has changed in a later version requiring referencing the first item